### PR TITLE
Invoke node drain job in the stop service monit job.

### DIFF
--- a/jobs/stop-portworx-service/monit
+++ b/jobs/stop-portworx-service/monit
@@ -1,5 +1,5 @@
 check process stop-portworx-service
   with pidfile /var/vcap/sys/run/stop-portworx-service/pid
   start program "/var/vcap/jobs/stop-portworx-service/bin/stop-px-and-unmount start" with timeout 120 seconds
-  stop program "/var/vcap/jobs/stop-portworx-service/bin/stop-px-and-unmount stop" with timeout 180 seconds
+  stop program "/var/vcap/jobs/stop-portworx-service/bin/stop-px-and-unmount stop" with timeout 360 seconds
   group vcap

--- a/jobs/stop-portworx-service/templates/stop-px-and-unmount.erb
+++ b/jobs/stop-portworx-service/templates/stop-px-and-unmount.erb
@@ -23,9 +23,19 @@ case $1 in
 
   stop)
     if [ -x /bin/systemctl ]; then
-      # If Portworx service is active, stop it
-      sudo systemctl is-active --quiet portworx && sudo systemctl stop portworx || \
+        # If Portworx service is active, stop it
+        sudo systemctl is-active --quiet portworx
+        if [ $? -eq 0 ]; then
+            /usr/bin/pxctl service node drain-attachments submit --node LocalNode -i bosh-monit -y -w
+            if [ $? -eq 0 ]; then
+                log "Successfully drained all volumes from this node,"
+            else
+                log "Failed to drain all volumes from this node"
+            fi
+            sudo systemctl stop portworx
+        else
 	    log "Portworx service not active."
+        fi
     else
       log "systemd not installed. Skipping stopping Portworx service."
     fi


### PR DESCRIPTION
- For older versions of PX, the command does not exist and we will simply log
  an error and continue. Same is the case for failed node drain jobs.
- Updated the stop monit timeout since the timeout on node drain job is 5 minutes.