### PR TITLE
Add a drain job for portworx

### DIFF
--- a/jobs/stop-portworx-service/monit
+++ b/jobs/stop-portworx-service/monit
@@ -1,5 +1,5 @@
 check process stop-portworx-service
   with pidfile /var/vcap/sys/run/stop-portworx-service/pid
   start program "/var/vcap/jobs/stop-portworx-service/bin/stop-px-and-unmount start" with timeout 120 seconds
-  stop program "/var/vcap/jobs/stop-portworx-service/bin/stop-px-and-unmount stop" with timeout 180 seconds
+  stop program "/var/vcap/jobs/stop-portworx-service/bin/stop-px-and-unmount stop" with timeout 360 seconds
   group vcap

--- a/jobs/stop-portworx-service/spec
+++ b/jobs/stop-portworx-service/spec
@@ -3,6 +3,7 @@ name: stop-portworx-service
 
 templates:
   stop-px-and-unmount.erb: bin/stop-px-and-unmount
+  drain-px.erb: bin/drain
 
 packages: []
 

--- a/jobs/stop-portworx-service/templates/drain-px.erb
+++ b/jobs/stop-portworx-service/templates/drain-px.erb
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+JOB_NAME=stop-portworx-service
+RUN_DIR=/var/vcap/sys/run/$JOB_NAME
+LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+PIDFILE=${RUN_DIR}/pid
+
+function log
+{
+    m_time=`date "+%F %T"`
+    echo $m_time" "$1
+}
+
+{
+if [ -x /bin/systemctl ]; then
+    # If Portworx service is active, invoke drain for volume attachments
+    sudo systemctl is-active --quiet portworx
+    if [ $? -eq 0 ]; then
+        /usr/bin/pxctl service node drain-attachments submit --node LocalNode -i bosh-monit -y -w
+        if [ $? -eq 0 ]; then
+            log "Successfully drained all volumes from this node,"
+        else
+            log "Failed to drain all volumes from this node"
+        fi
+    else
+        log "Portworx service not active."
+    fi
+else
+    log "systemd not installed. Skipping drain of volume attachments."
+fi
+} >>  $LOG_DIR/$JOB_NAME.drain.stdout.log 2>>$LOG_DIR/$JOB_NAME.drain.stderr.log

--- a/jobs/stop-portworx-service/templates/drain-px.erb
+++ b/jobs/stop-portworx-service/templates/drain-px.erb
@@ -5,13 +5,37 @@ RUN_DIR=/var/vcap/sys/run/$JOB_NAME
 LOG_DIR=/var/vcap/sys/log/$JOB_NAME
 PIDFILE=${RUN_DIR}/pid
 
+trap ensure_safe_exit EXIT
+
 function log
 {
     m_time=`date "+%F %T"`
     echo $m_time" "$1
 }
 
-{
+ensure_safe_exit() {
+    exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        echo "Portworx drain failed"
+        exit $exit_code
+    fi
+    echo 0 >&3
+}
+
+save_stdout_to_fd3() {
+    exec 3>&1
+}
+
+send_process_stdout_to_logfile() {
+    save_stdout_to_fd3
+    exec 1>> "$LOG_DIR/drain.stdout.log"
+}
+
+send_process_stderr_to_logfile() {
+    exec 2>> "$LOG_DIR/drain.stderr.log"
+}
+
+portworx_drain() {
 if [ -x /bin/systemctl ]; then
     # If Portworx service is active, invoke drain for volume attachments
     sudo systemctl is-active --quiet portworx
@@ -28,4 +52,15 @@ if [ -x /bin/systemctl ]; then
 else
     log "systemd not installed. Skipping drain of volume attachments."
 fi
-} >>  $LOG_DIR/$JOB_NAME.drain.stdout.log 2>>$LOG_DIR/$JOB_NAME.drain.stderr.log
+}
+
+main() {
+    send_process_stdout_to_logfile
+    send_process_stderr_to_logfile
+
+    portworx_drain
+    # Always succeed portworx node drain - We don't want to block bosh node drain operation
+    return 0
+}
+
+main

--- a/jobs/stop-portworx-service/templates/stop-px-and-unmount.erb
+++ b/jobs/stop-portworx-service/templates/stop-px-and-unmount.erb
@@ -23,19 +23,9 @@ case $1 in
 
   stop)
     if [ -x /bin/systemctl ]; then
-        # If Portworx service is active, stop it
-        sudo systemctl is-active --quiet portworx
-        if [ $? -eq 0 ]; then
-            /usr/bin/pxctl service node drain-attachments submit --node LocalNode -i bosh-monit -y -w
-            if [ $? -eq 0 ]; then
-                log "Successfully drained all volumes from this node,"
-            else
-                log "Failed to drain all volumes from this node"
-            fi
-            sudo systemctl stop portworx
-        else
+      # If Portworx service is active, stop it
+      sudo systemctl is-active --quiet portworx && sudo systemctl stop portworx || \
 	    log "Portworx service not active."
-        fi
     else
       log "systemd not installed. Skipping stopping Portworx service."
     fi

--- a/jobs/stop-portworx-service/templates/stop-px-and-unmount.erb
+++ b/jobs/stop-portworx-service/templates/stop-px-and-unmount.erb
@@ -23,9 +23,19 @@ case $1 in
 
   stop)
     if [ -x /bin/systemctl ]; then
-      # If Portworx service is active, stop it
-      sudo systemctl is-active --quiet portworx && sudo systemctl stop portworx || \
+        # If Portworx service is active, stop it
+        sudo systemctl is-active --quiet portworx
+        if [ $? -eq 0 ]; then
+            /usr/bin/pxctl service node drain-attachments submit --node LocalNode -i bosh-monit -y -w
+            if [ $? -eq 0 ]; then
+                log "Successfully drained all volumes from this node,"
+            else
+                log "Failed to drain all volumes from this node"
+            fi
+            sudo systemctl stop portworx
+        else
 	    log "Portworx service not active."
+        fi
     else
       log "systemd not installed. Skipping stopping Portworx service."
     fi


### PR DESCRIPTION
- Add a new drain script that drains volume attachments
- For older versions of PX, the command does not exist and we will simply log
an error and continue. Same is the case for failed node drain jobs.
- Updated the stop monit timeout since the timeout on node drain job is 5 minutes.