### PR TITLE
PWX-35931: Change drain script to pre-stop

### DIFF
--- a/jobs/stop-portworx-service/spec
+++ b/jobs/stop-portworx-service/spec
@@ -3,7 +3,7 @@ name: stop-portworx-service
 
 templates:
   stop-px-and-unmount.erb: bin/stop-px-and-unmount
-  drain-px.erb: bin/drain
+  drain-px.erb: bin/pre-stop
 
 packages: []
 


### PR DESCRIPTION
    kubo release in PKS now drains in pre-stop and not in the drain
    stage. Changing our drain script to pre-stop

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

